### PR TITLE
Support per-project rdbgrc(.rb) files

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -2032,11 +2032,13 @@ module DEBUGGER__
   end
 
   def self.load_rc
-    [[File.expand_path('~/.rdbgrc'), true],
-     [File.expand_path('~/.rdbgrc.rb'), true],
-     # ['./.rdbgrc', true], # disable because of security concern
-     [CONFIG[:init_script], false],
-     ].each{|(path, rc)|
+    [
+      [File.expand_path('~/.rdbgrc'), true],
+      [File.expand_path('~/.rdbgrc.rb'), true],
+      [File.join(Dir.pwd, '.rdbgrc'), true],
+      [File.join(Dir.pwd, '.rdbgrc.rb'), true],
+      [CONFIG[:init_script], false],
+    ].each{|(path, rc)|
       next unless path
       next if rc && CONFIG[:no_rc] # ignore rc
 

--- a/test/console/rdbg_option_test.rb
+++ b/test/console/rdbg_option_test.rb
@@ -56,11 +56,7 @@ module DEBUGGER__
     end
   end
 
-  class RCFileTest < ConsoleTestCase
-    def rc_filename
-      File.join(pty_home_dir, ".rdbgrc")
-    end
-
+  module RCFileTests
     def rc_script
       "config set skip_path /foo/bar/"
     end
@@ -97,6 +93,22 @@ module DEBUGGER__
           type "c"
         end
       end
+    end
+  end
+
+  class GlobalRCFileTest < ConsoleTestCase
+    include RCFileTests
+
+    def rc_filename
+      File.join(pty_home_dir, ".rdbgrc")
+    end
+  end
+
+  class LocalRCFileTest < ConsoleTestCase
+    include RCFileTests
+
+    def rc_filename
+      File.join(Dir.pwd, ".rdbgrc")
     end
   end
 


### PR DESCRIPTION
Each project may have its own project-specific debugger configuration, like different paths to skip. So the debugger should also read `rdbgrc` files at the project root, similar to what `irb` does with `irbrc`.