### PR TITLE
Support functional `setFunctionBreakpoints` command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -353,6 +353,16 @@ req_set_exception_breakpoints([])
 
 to clear all exception breakpoints.
 
+- res_set_function_breakpoints(breakpoints)
+
+Sends request to rdbg to set function breakpoints. e.g.
+
+```rb
+req_set_function_breakpoints([{ name: "Foo#bar", condition: "a == 1" }])
+```
+
+Like `req_set_exception_breakpoints`, it also resets all function breakpoints in every request.
+
 - req_continue
 
 Sends request to rdbg to resume the program.

--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -639,7 +639,7 @@ module DEBUGGER__
 
         breakpoints = bps.map do |bp|
           if bp["name"]&.match(Session::METHOD_SIGNATURE_REGEXP)
-            make_breakpoint [:method, $1, $2, $3]
+            make_breakpoint [:method, $1, $2, $3, bp["condition"]]
           end
         end
 

--- a/test/protocol/break_test.rb
+++ b/test/protocol/break_test.rb
@@ -63,6 +63,13 @@ module DEBUGGER__
       end
     end
 
+    def test_set_function_breakpoints_sets_breakpoint_with_condition
+      run_protocol_scenario PROGRAM, cdp: false do
+        res_set_function_breakpoints([{ name: "Foo.bar", condition: "$foo == 1" }])
+        req_continue
+      end
+    end
+
     def test_set_function_breakpoints_sets_class_method_breakpoints
       run_protocol_scenario PROGRAM, cdp: false do
         req_add_breakpoint 13

--- a/test/protocol/break_test.rb
+++ b/test/protocol/break_test.rb
@@ -5,41 +5,84 @@ require_relative '../support/protocol_test_case'
 module DEBUGGER__
   class BreakTest1 < ProtocolTestCase
     PROGRAM = <<~RUBY
-      1| module Foo
-      2|   class Bar
-      3|     def self.a
-      4|       "hello"
-      5|     end
-      6|   end
-      7|   Bar.a
-      8|   bar = Bar.new
-      9| end
+     1| class Foo
+     2|   def self.bar
+     3|     "hello"
+     4|   end
+     5|
+     6|   def baz
+     7|     10
+     8|   end
+     9| end
+    10|
+    11| Foo.bar
+    12| f = Foo.new
+    13| f.baz
     RUBY
 
-    def test_break_stops_at_correct_place
+    def test_set_breakpoints_sets_line_breakpoints
       run_protocol_scenario PROGRAM do
-        req_add_breakpoint 5
+        req_add_breakpoint 4
         req_continue
-        assert_line_num 5
+        assert_line_num 4
 
         assert_locals_result(
           [
-            { name: "%self", value: "Foo::Bar", type: "Class" },
+            { name: "%self", value: "Foo", type: "Class" },
             { name: "_return", value: "hello", type: "String" }
           ]
         )
 
-        req_add_breakpoint 9
+        req_add_breakpoint 13
         req_continue
-        assert_line_num 9
+        assert_line_num 13
 
         assert_locals_result(
           [
-            { name: "%self", value: "Foo", type: "Module" },
-            { name: "bar", value: /#<Foo::Bar/, type: "Foo::Bar" }
+            { name: "%self", value: "main", type: "Object" },
+            { name: "f", value: /#<Foo.*>/, type: "Foo" }
           ]
         )
         req_terminate_debuggee
+      end
+    end
+
+    def test_set_function_breakpoints_sets_instance_method_breakpoints
+      run_protocol_scenario PROGRAM, cdp: false do
+        res_set_function_breakpoints([{ name: "Foo.bar" }])
+        req_continue
+        assert_line_num 3
+
+        assert_locals_result(
+          [
+            { name: "%self", value: "Foo", type: "Class" }
+          ]
+        )
+
+        req_continue
+      end
+    end
+
+    def test_set_function_breakpoints_sets_class_method_breakpoints
+      run_protocol_scenario PROGRAM, cdp: false do
+        req_add_breakpoint 13
+        req_continue
+        assert_line_num 13
+
+        res_set_function_breakpoints([{ name: "f.baz" }])
+        req_continue
+
+        assert_line_num 7
+
+        req_terminate_debuggee
+      end
+    end
+
+    def test_set_function_breakpoints_unsets_method_breakpoints
+      run_protocol_scenario PROGRAM, cdp: false do
+        res_set_function_breakpoints([{ name: "Foo::Bar.a" }])
+        res_set_function_breakpoints([])
+        req_continue
       end
     end
   end

--- a/test/support/protocol_test_case.rb
+++ b/test/support/protocol_test_case.rb
@@ -137,6 +137,13 @@ module DEBUGGER__
       end
     end
 
+    def res_set_function_breakpoints(breakpoints)
+      case ENV['RUBY_DEBUG_TEST_UI']
+      when 'vscode'
+        send_dap_request 'setFunctionBreakpoints', breakpoints: breakpoints
+      end
+    end
+
     def req_step_back
       case ENV['RUBY_DEBUG_TEST_UI']
       when 'vscode'


### PR DESCRIPTION
Currently, DAP server responds to `setFunctionBreakpoints` command but it doesn't really do anything. This PR enables adding/removing method breakpoints.

Supported breakpoint types:

```rb
class Foo
  def foo
  end

  def self.bar
  end
end

foo = Foo.new
```

- `Foo#foo` - will stop at `Foo`'s instance method `foo`
- `Foo.bar` - will stop at `Foo`'s singleton method `bar`

This is not intentionally supported but currently it works:

- `foo.foo` - will stop at `foo` object's `#foo` method call


Condition is also supported:

<img width="60%" alt="截圖 2022-05-04 11 04 22" src="https://user-images.githubusercontent.com/5079556/166661710-8ca5d60b-7b44-4dc5-ae0c-1cc5160051df.png">

### Demos

**Function Breakpoint**


https://user-images.githubusercontent.com/5079556/166662824-9771d9bd-d6f8-4252-a366-5c2897462bb9.mov

**Function Breakpoint with Conditions**


https://user-images.githubusercontent.com/5079556/166663070-8fa9e2e4-1143-4b33-85f4-f3b394e1ecca.mov



